### PR TITLE
Add page transition links and localize into Japanese

### DIFF
--- a/app/src/Template/Coordinates/create.ctp
+++ b/app/src/Template/Coordinates/create.ctp
@@ -132,10 +132,10 @@
 <div class="picked_items_area">
     <div class="picked_items_message">選択済みのアイテム</div>
     <div style="position: relative; float: right;">
-    <?= $this->html->link(
+    <?= $this->Html->link(
         '>> コーディネートを作成',
         [
-            'controller' => 'coordinates',
+            'controller' => 'Coordinates',
             'action' => 'post',
         ],
         [

--- a/app/src/Template/Coordinates/create.ctp
+++ b/app/src/Template/Coordinates/create.ctp
@@ -13,46 +13,46 @@
 <table class="search_area">
     <?= $this->Form->create() ?>
     <tr>
-        <td class="search_label">Sex</td>
+        <td class="search_label">性別</td>
         <td class="search_value">
             <?= $this->Form->input(
                 'sex',
                 [
                     'label' => '',
                     'options' => $sex_list,
-                    'empty' => 'Choose one',
+                    'empty' => '指定なし',
                 ]
             ); ?>
         </td>
     </tr>
     <tr>
-        <td class="search_label">Category</td>
+        <td class="search_label">種類</td>
         <td class="search_value">
             <?= $this->Form->input(
                 'category',
                 [
                     'label' => '',
                     'options' => $category_list,
-                    'empty' => 'Choose one',
+                    'empty' => '指定なし',
                 ]
             ); ?>
         </td>
     </tr>
     <tr>
-        <td class="search_label">Color</td>
+        <td class="search_label">カラー</td>
         <td class="search_value">
             <?= $this->Form->input(
                 'color',
                 [
                     'label' => '',
                     'options' => $color_list,
-                    'empty' => 'Choose one',
+                    'empty' => '指定なし',
                 ]
             ); ?>
         </td>
     </tr>
     <tr>
-        <td class="search_label">Price</td>
+        <td class="search_label">価格帯</td>
         <td class="search_value">
             <?= $this->Form->input(
                 'price',
@@ -64,14 +64,14 @@
                         '3001,5000' => '¥3001 - ¥5000',
                         '5001,10000' => '¥5001 - ¥10000',
                     ],
-                    'empty' => 'Choose one',
+                    'empty' => '指定なし',
                 ]
             ); ?>
         </td>
     </tr>
     <tr class="search_button">
         <td colspan="2">
-            <?= $this->Form->button('Search') ?>
+            <?= $this->Form->button('検索') ?>
             <?= $this->Form->end() ?>
         </td>
     </tr>
@@ -130,19 +130,21 @@
 </div>
 
 <div class="picked_items_area">
-    <div class="picked_items_message">Picked Items</div>
-    <div class="picked_items"></div>
-    <?= $this->Html->link(
-        '>> Next step',
+    <div class="picked_items_message">選択済みのアイテム</div>
+    <div style="position: relative; float: right;">
+    <?= $this->html->link(
+        '>> コーディネートを作成',
         [
-            'controller' => 'Coordinates',
+            'controller' => 'coordinates',
             'action' => 'post',
         ],
         [
             'class' => 'link_to_post',
         ]
     ) ?>
+    </div>
+    <div style="clear: both;"></div>
+    <div class="picked_items"></div>
 </div>
-
 </body>
 </html>

--- a/app/src/Template/Coordinates/post.ctp
+++ b/app/src/Template/Coordinates/post.ctp
@@ -25,6 +25,20 @@
 
     <button onclick="screenshot('#screen')" , style="position: relative; float: right; margin: 30px;">投稿</button>
 
+    <div style="clear: both;"></div>
+    <br />
+    <div style="position: relative; float: left;">
+    <?= $this->html->link(
+        '<< アイテムを選びなおす',
+        [
+            'controller' => 'coordinates',
+            'action' => 'create',
+        ],
+        [
+            'class' => 'link_to_post',
+        ]
+    ) ?>
+    </div>
     <script>
         var zIndex = 0;
 

--- a/app/webroot/css/coordinates/create.css
+++ b/app/webroot/css/coordinates/create.css
@@ -62,7 +62,6 @@
 }
 
 .picked_items_area {
-    height: 170px;
     width: 100%;
     bottom: 0;
     position: fixed;
@@ -72,7 +71,14 @@
 }
 
 .picked_items_message {
+    position: relative;
+    float: left;
     font-size: 16px;
+}
+
+.picked_items {
+  position: relative;
+  float: left;
 }
 
 .picked_item {


### PR DESCRIPTION
・アイテム選択画面でアイテムを沢山選択すると次のページへ進むリンクが消える不具合を修正
・コーディネート作成画面からアイテム選択画面へ戻れるリンクを追加
・前回会議の方針に従って日本語にローカライズ
