### PR TITLE
Add debug_kit connection

### DIFF
--- a/app/config/app.default.php
+++ b/app/config/app.default.php
@@ -270,6 +270,22 @@ return [
             //'init' => ['SET GLOBAL innodb_stats_on_metadata = 0'],
             'log' => true,
         ],
+        'debug_kit' => [
+            'className' => 'Cake\Database\Connection',
+            'driver' => 'Cake\Database\Driver\Mysql',
+            'persistent' => false,
+            'host' => 'localhost',
+            //'port' => 'nonstandard_port_number',
+            'username' => 'my_app',
+            'password' => 'secret',
+            'database' => 'test_myapp',
+            'encoding' => 'utf8',
+            'timezone' => 'UTC',
+            'cacheMetadata' => true,
+            'quoteIdentifiers' => false,
+            //'init' => ['SET GLOBAL innodb_stats_on_metadata = 0'],
+            'log' => true,
+        ],
     ],
 
     /**


### PR DESCRIPTION
https://github.com/enpitut/cynts/pull/110 によって，app/log/debug.log に sql のログが吐かれるようになったが，本番環境では debugKit をインストールしていないため，app/log/error.log に以下のようなエラーが吐かれていたのを直した

```
Warning: DebugKit not enabled. You need to either install pdo_sqlite, or define the "debug_kit" connection name
```
