### PR TITLE
Fix season search

### DIFF
--- a/app/src/Model/Criteria/CoordinatesCriteria.php
+++ b/app/src/Model/Criteria/CoordinatesCriteria.php
@@ -135,15 +135,15 @@ class CoordinatesCriteria {
     }
 
     /**
-     * 季節の情報は春夏秋冬を4bitのビット列で保持する
-     * ビットが立っていれば 1，そうでなければ_(任意の一文字)を正規表現に加える
+     * coordinates.season は 4bit の bit 列を string 型で保存している．
+     * MySQL の仕様で，bitwise and 演算子は入力を10進数として，その論理積を取る．
+     * coordinates.season に保存されている値と，この関数で生成する $expression は2進数であるため，
+     * MySQL の CONV 関数で2進数から10進数に変換している．
      *
-     * SQL(夏，秋がチェックされている場合):
-     *   Coordinates.season LIKE :c0
-     *   - :c0 正規表現．例) 春と秋がチェックされている場合は "1_1_%"
+     * また，cake の ORM が bitwise and 演算子をサポートしていないため，クエリをベタ書きしている．
+     * $expression はここで生成された値であるため，ユーザーが任意のクエリを発行できるわけではないが，要注意．
      *
      * @param string $season_criteria 形式は4bitのビット列  例) "1010"
-     *
      * @return \Cake\ORM\Query $criteria_query
      */
     private static function _createQueryMatchSeasonCriteria($season_criteria)

--- a/app/src/Model/Criteria/CoordinatesCriteria.php
+++ b/app/src/Model/Criteria/CoordinatesCriteria.php
@@ -148,16 +148,15 @@ class CoordinatesCriteria {
      */
     private static function _createQueryMatchSeasonCriteria($season_criteria)
     {
-        $expression = "";
-        foreach(str_split($season_criteria) as $season_flag){
-            $expression .= $season_flag === "1" ? "1" : "_";
+        $expression = '';
+        foreach (str_split($season_criteria) as $season_flag) {
+            $expression .= $season_flag === '1' ? '1' : '0';
         }
-        $expression .= '%';
 
-        $criteria_query = TableRegistry::get('Coordinates')->find()->newExpr()->like(
-            'Coordinates.season',
-            $expression
-        );
+        $criteria_query = TableRegistry::get('Coordinates')->find()->newExpr()
+            ->add(
+                ["CONV(Coordinates.season, 2, 10) & CONV($expression, 2, 10)"]
+            );
         return $criteria_query;
     }
 }


### PR DESCRIPTION
2進数で保存されていた coordinates.season を検索する際に，正規表現による検索から，MySQL の bitwise and 演算子による検索に変更
同時にバグも解消された

refer : http://dev.mysql.com/doc/refman/5.7/en/bit-functions.html
