### PR TITLE
Fix ranking information layout

### DIFF
--- a/app/src/Template/Rankings/view.ctp
+++ b/app/src/Template/Rankings/view.ctp
@@ -59,26 +59,30 @@
                     ) ?>
                 </div>
                 <div class="information">
-                    <div class="information_left">
-                        <div class="point">
-                            <span class="point_number" id="point_<?= $rank ?>">
-                                <?php
-                                if ($type
-                                    === \App\Controller\RankingsController::RANKING_TYPE_LIKE
-                                ) {
-                                    echo $coordinate->n_like;
-                                } else {
-                                    echo $coordinate->n_unlike;
-                                }
-                                ?>
-                            </span> points
+                    <div class="information_up">
+                        <div class="information_left">
+                            <div class="point">
+                                <span class="point_number" id="point_<?= $rank ?>">
+                                    <?php
+                                    if ($type
+                                        === \App\Controller\RankingsController::RANKING_TYPE_LIKE
+                                    ) {
+                                        echo $coordinate->n_like;
+                                    } else {
+                                        echo $coordinate->n_unlike;
+                                    }
+                                    ?>
+                                </span> points
+                            </div>
                         </div>
-                        <div class="total_price">
-                            ¥<span class="price_number"
-                                   id="price_<?= $rank ?>"><?= $coordinate->price ?></span>
+                        <div class="information_right">
+                            <div class="total_price">
+                                ¥<span class="price_number"
+                                       id="price_<?= $rank ?>"><?= $coordinate->price ?></span>
+                            </div>
                         </div>
                     </div>
-                    <div class="information_right">
+                    <div class="information_bottom">
                         <div class="user">
                             <?php if (isset($coordinate->user->name)) { ?>
                                 制作者 :

--- a/app/webroot/css/ranking/base.css
+++ b/app/webroot/css/ranking/base.css
@@ -50,24 +50,38 @@ body {
     font-size: 12px;
     padding: 0 4px;
     color: darkgray;
+ }
+
+.information_up {
+    width: 100%;
+    height: 20px;
+    position: relative;
 }
 
 .information_left {
     float: left;
     text-align: left;
+    position: absolute;
+    bottom: 0;
+    left: 0;
 }
 
 .information_right {
     float: right;
     text-align: right;
+    position: absolute;
+    bottom: 0;
+    right: 0;
 }
 
-.information .point {
-    float: left;
+.information_bottom {
+    float: right;
+    text-align: right;
+    width: 100%;
 }
 
 .information .point .point_number {
-    font-size: 14px;
+    font-size: 18px;
     color: darkorange;
 }
 

--- a/app/webroot/html/rankings/ranking_template.html
+++ b/app/webroot/html/rankings/ranking_template.html
@@ -8,15 +8,19 @@
         </a>
     </div>
     <div class="information">
-        <div class="information_left">
-            <div class="point">
-                <span class="point_number">#{coordinates_score}</span> Points
+        <div class="information_up">
+            <div class="information_left">
+                <div class="point">
+                    <span class="point_number">#{coordinates_score}</span> Points
+                </div>
             </div>
-            <div class="total_price">
-                ¥<span class="price_number">#{coordinates_price}</span>
+            <div class="information_right">
+                <div class="total_price">
+                    ¥<span class="price_number">#{coordinates_price}</span>
+                </div>
             </div>
         </div>
-        <div class="information_right">
+        <div class="infomation_bottom">
             #{coordinates_user_information}
         </div>
     </div>
@@ -32,15 +36,19 @@
         </a>
     </div>
     <div class="information">
-        <div class="information_left">
-            <div class="point">
-                <span class="point_number">#{coordinates_score}</span> Points
+        <div class="information_up">
+            <div class="information_left">
+                <div class="point">
+                    <span class="point_number">#{coordinates_score}</span> Points
+                </div>
             </div>
-            <div class="total_price">
-                ¥<span class="price_number">#{coordinates_price}</span>
+            <div class="information_right">
+                <div class="total_price">
+                    ¥<span class="price_number">#{coordinates_price}</span>
+                </div>
             </div>
         </div>
-        <div class="information_right">
+        <div class="infomation_bottom">
             #{coordinates_user_information}
         </div>
     </div>


### PR DESCRIPTION
ユーザー名が長い時にランキングのインフォメーション欄のレイアウトが崩れるのを直した
ユーザー名が長い場合は制作者：　の部分で改行される

![a](https://gyazo.com/95ebf506140535fbbc9b201f64206a08.png)
